### PR TITLE
Fixed mangling of stdout & stderr that then was piped as 'unlock password' to cryptsetup, resulting in a failed unlock

### DIFF
--- a/unl0kr-hooks
+++ b/unl0kr-hooks
@@ -35,7 +35,7 @@ EOF
                 echo "A password is required to access the ${cryptname} volume"
                 #loop until we get a real password
                 while ! [ -b "/dev/mapper/${cryptname}" ]; do
-                    unl0kr | cryptsetup open "${cryptdev}" "${cryptname}"
+                    unl0kr 2> /dev/null | cryptsetup open "${cryptdev}" "${cryptname}"
                     export CRYPTTAB_TRIED=1
                 done
             fi


### PR DESCRIPTION
When running unl0kr on my system (Surface Pro 7) the password (stdout) is quite often mangled with stderr and then piped to cryptsetup, fialing to unlock my disk.

Ways to reproduce:
```
# Run as root on a dedicated tty
unl0kr | cat
```

Output:
![20240225_182455](https://github.com/Grosskopf/arch_unl0kr/assets/30482165/45010a25-75eb-4e34-802c-0b825b22b550)

The password used here was "asdf". As you can see, there is a lot of stderr happening and sometimes stderr and stdout is mangled. The result is then piped to cryptsetup as password, failing to unlock the disk.

Soluction: Get rid of stderr, as in my patch